### PR TITLE
Add Node Dialog Tab for advanced tesseract configuration

### DIFF
--- a/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeDialog.java
+++ b/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeDialog.java
@@ -109,7 +109,10 @@ public class Tess4JNodeDialog<T extends RealType<T>> extends ValueToCellNodeDial
 		buildDialog();
 	}
 
-	public void createOptionsTab() {
+	/**
+	 * Create a tab which contains basic tesseract settings.
+	 */
+	private void createOptionsTab() {
 		final JPanel contentPane = new JPanel();
 		contentPane.setLayout(new GridBagLayout());
 
@@ -169,7 +172,11 @@ public class Tess4JNodeDialog<T extends RealType<T>> extends ValueToCellNodeDial
 		m_dialogComponents.add(deskewComp);
 	}
 
-	public void createAdvancedConfigTab() {
+	/**
+	 * Create a tab which contains a table to manually set tesseract config
+	 * key-value pairs.
+	 */
+	private void createAdvancedConfigTab() {
 		final JPanel contents = new JPanel(new BorderLayout());
 		final TessConfigTable tessConfigTable = new TessConfigTable(m_settings.tessAdvancedConfigModel());
 

--- a/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeDialog.java
+++ b/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeDialog.java
@@ -193,6 +193,10 @@ public class Tess4JNodeDialog<T extends RealType<T>> extends ValueToCellNodeDial
 		btnDel.addActionListener(
 				(evt) -> m_tessConfigTable.model().removeConfigEntry(m_tessConfigTable.table().getSelectedRow()));
 
+		/* clear button */
+		final JButton btnClear = new JButton("Clear");
+		btnClear.addActionListener((evt) -> clearTessConfig());
+
 		contents.add(m_tessConfigTable.getComponentPanel(), BorderLayout.CENTER);
 
 		final JPanel labelPanel = new JPanel(new GridBagLayout());
@@ -214,6 +218,21 @@ public class Tess4JNodeDialog<T extends RealType<T>> extends ValueToCellNodeDial
 		addTab("Advanced Config", contents);
 
 		m_dialogComponents.add(m_tessConfigTable);
+	}
+
+	/**
+	 * Ask user for confirmation and then possibly clear all config values from
+	 * the advanced tesseract configuration table.
+	 */
+	private void clearTessConfig() {
+		/* ask for confirmation */
+		if (JOptionPane.showConfirmDialog(getPanel(), "Delete all config values?\n(Cannot be undone.)", "Confirm",
+				JOptionPane.OK_CANCEL_OPTION) == JOptionPane.CANCEL_OPTION) {
+			return;
+		}
+
+		m_tessConfigTable.model().contents().clear();
+		m_tessConfigTable.model().fireTableDataChanged();
 	}
 
 	@Override

--- a/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeDialog.java
+++ b/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeDialog.java
@@ -61,9 +61,6 @@ import javax.swing.JPanel;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
-import net.imglib2.type.numeric.RealType;
-import net.sourceforge.tess4j.ITesseract;
-
 import org.knime.core.data.DataTableSpec;
 import org.knime.core.node.InvalidSettingsException;
 import org.knime.core.node.NodeSettingsRO;
@@ -74,6 +71,9 @@ import org.knime.core.node.defaultnodesettings.DialogComponentBoolean;
 import org.knime.core.node.defaultnodesettings.DialogComponentStringSelection;
 import org.knime.knip.base.data.img.ImgPlusValue;
 import org.knime.knip.base.node.ValueToCellNodeDialog;
+
+import net.imglib2.type.numeric.RealType;
+import net.sourceforge.tess4j.ITesseract;
 
 /**
  * Tess4JNodeDialog
@@ -86,15 +86,15 @@ import org.knime.knip.base.node.ValueToCellNodeDialog;
  * @author <a href="mailto:michael.zinsmaier@googlemail.com">Michael
  *         Zinsmaier</a>
  */
-public class Tess4JNodeDialog<T extends RealType<T>> extends
-		ValueToCellNodeDialog<ImgPlusValue<T>> implements ChangeListener {
+public class Tess4JNodeDialog<T extends RealType<T>> extends ValueToCellNodeDialog<ImgPlusValue<T>>
+		implements ChangeListener {
 
 	private DialogComponentStringSelection m_languageListComponent;
 	private DialogComponentAlternatePathChooser m_pathChooser;
 
 	private final Tess4JNodeSettings m_settings = new Tess4JNodeSettings();
 	private final List<String> m_languages = new ArrayList<String>();
-	
+
 	private final List<DialogComponent> m_dialogComponents = new ArrayList<DialogComponent>();
 
 	public Tess4JNodeDialog() {
@@ -105,57 +105,57 @@ public class Tess4JNodeDialog<T extends RealType<T>> extends
 	}
 
 	public void createOptionsTab() {
-		JPanel contentPane = new JPanel();
+		final JPanel contentPane = new JPanel();
 		contentPane.setLayout(new GridBagLayout());
-		
-		JPanel preprocessingPane = new JPanel();
+
+		final JPanel preprocessingPane = new JPanel();
 		preprocessingPane.setBorder(BorderFactory.createTitledBorder("Preprocessing"));
-		
-		JPanel recogPane = new JPanel(new GridBagLayout());
+
+		final JPanel recogPane = new JPanel(new GridBagLayout());
 		recogPane.setBorder(BorderFactory.createTitledBorder("Recognition Configuration"));
-		
-		DialogComponentBoolean deskewComp = new DialogComponentBoolean(
-				m_settings.deskewModel(), "Deskew input images");
-		DialogComponentStringIndexSelection pageSegComp = new DialogComponentStringIndexSelection(
-				m_settings.pageSegModeModel(), "Page Segmentation Mode",
-				ITesseract.PageSegMode.m_valueNames);
-		DialogComponentStringIndexSelection ocrModeComp = new DialogComponentStringIndexSelection(
-				m_settings.ocrEngineModeModel(), "OCR Engine Mode",
-				ITesseract.OcrEngineMode.m_valueNames);
+
+		final DialogComponentBoolean deskewComp = new DialogComponentBoolean(m_settings.deskewModel(),
+				"Deskew input images");
+		final DialogComponentStringIndexSelection pageSegComp = new DialogComponentStringIndexSelection(
+				m_settings.pageSegModeModel(), "Page Segmentation Mode", ITesseract.PageSegMode.m_valueNames);
+		final DialogComponentStringIndexSelection ocrModeComp = new DialogComponentStringIndexSelection(
+				m_settings.ocrEngineModeModel(), "OCR Engine Mode", ITesseract.OcrEngineMode.m_valueNames);
 
 		final int ANCHOR = GridBagConstraints.FIRST_LINE_START;
 		final int FILL = GridBagConstraints.HORIZONTAL;
-		
+
 		final Insets insets = new Insets(0, 4, 0, 4);
 		final GridBagConstraints gbc_deskew = new GridBagConstraints(0, 0, 2, 1, 0.0, 0.0, ANCHOR, FILL, insets, 0, 0);
-		final GridBagConstraints gbc_pathChooser = new GridBagConstraints(0, 1, 1, 1, 0.0, 0.0, ANCHOR, FILL, insets, 0, 0);
+		final GridBagConstraints gbc_pathChooser = new GridBagConstraints(0, 1, 1, 1, 0.0, 0.0, ANCHOR, FILL, insets, 0,
+				0);
 		final GridBagConstraints gbc_recog = new GridBagConstraints(0, 2, 1, 1, 1.0, 1.0, ANCHOR, FILL, insets, 0, 0);
-		
-		final GridBagConstraints gbc_language = new GridBagConstraints(0, 1, 2, 1, 1.0, 0.0, ANCHOR, FILL, insets, 0, 0);
-		final GridBagConstraints gbc_pageSet = new GridBagConstraints(0, 2, 1, 1, 1.0, 0.0, ANCHOR, FILL, insets, 0, 0);
-		final GridBagConstraints gbc_ocrEngine = new GridBagConstraints(1, 2, 1, 1, 1.0, 1.0, ANCHOR, FILL, insets, 0, 0);
-		
-		updateLanguages();
-		m_languageListComponent = new DialogComponentStringSelection(
-				m_settings.languageModel(), "Language", m_languages);
 
-		m_pathChooser = new DialogComponentAlternatePathChooser(
-				"Tessdata Path", m_settings.pathModel());
+		final GridBagConstraints gbc_language = new GridBagConstraints(0, 1, 2, 1, 1.0, 0.0, ANCHOR, FILL, insets, 0,
+				0);
+		final GridBagConstraints gbc_pageSet = new GridBagConstraints(0, 2, 1, 1, 1.0, 0.0, ANCHOR, FILL, insets, 0, 0);
+		final GridBagConstraints gbc_ocrEngine = new GridBagConstraints(1, 2, 1, 1, 1.0, 1.0, ANCHOR, FILL, insets, 0,
+				0);
+
+		updateLanguages();
+		m_languageListComponent = new DialogComponentStringSelection(m_settings.languageModel(), "Language",
+				m_languages);
+
+		m_pathChooser = new DialogComponentAlternatePathChooser("Tessdata Path", m_settings.pathModel());
 
 		m_settings.pathModel().addChangeListener(this);
 
 		preprocessingPane.add(deskewComp.getComponentPanel());
 		contentPane.add(preprocessingPane, gbc_deskew);
-		
+
 		contentPane.add(m_pathChooser.getComponentPanel(), gbc_pathChooser);
-		
+
 		recogPane.add(m_languageListComponent.getComponentPanel(), gbc_language);
 		recogPane.add(pageSegComp.getComponentPanel(), gbc_pageSet);
 		recogPane.add(ocrModeComp.getComponentPanel(), gbc_ocrEngine);
 		contentPane.add(recogPane, gbc_recog);
-		
+
 		addTab("Settings", contentPane);
-		
+
 		// add dialog components to list
 		m_dialogComponents.add(m_pathChooser);
 		m_dialogComponents.add(m_languageListComponent);
@@ -197,8 +197,7 @@ public class Tess4JNodeDialog<T extends RealType<T>> extends
 					continue;
 				}
 
-				m_languages.add(langFilename.substring(0,
-						langFilename.length() - 12));
+				m_languages.add(langFilename.substring(0, langFilename.length() - 12));
 			}
 		}
 
@@ -213,25 +212,23 @@ public class Tess4JNodeDialog<T extends RealType<T>> extends
 	}
 
 	@Override
-	public void saveAdditionalSettingsTo(final NodeSettingsWO settings)
-			throws InvalidSettingsException {
+	public void saveAdditionalSettingsTo(final NodeSettingsWO settings) throws InvalidSettingsException {
 		if (!updateLanguages()) {
-			throw new InvalidSettingsException(
-					"No tesseract language (.tessdata) files found in selected path.");
+			throw new InvalidSettingsException("No tesseract language (.tessdata) files found in selected path.");
 		}
 
 		for (DialogComponent comp : m_dialogComponents) {
 			comp.saveSettingsTo(settings);
 		}
-		
+
 		super.saveAdditionalSettingsTo(settings);
 	}
-	
+
 	@Override
-	public void loadAdditionalSettingsFrom(NodeSettingsRO settings,
-			DataTableSpec[] specs) throws NotConfigurableException {
+	public void loadAdditionalSettingsFrom(NodeSettingsRO settings, DataTableSpec[] specs)
+			throws NotConfigurableException {
 		super.loadAdditionalSettingsFrom(settings, specs);
-		
+
 		for (DialogComponent comp : m_dialogComponents) {
 			comp.loadSettingsFrom(settings, specs);
 		}

--- a/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeDialog.java
+++ b/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeDialog.java
@@ -48,6 +48,7 @@
  */
 package org.knime.knip.tess4j.base.node;
 
+import java.awt.BorderLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -57,6 +58,8 @@ import java.util.Collections;
 import java.util.List;
 
 import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -71,6 +74,7 @@ import org.knime.core.node.defaultnodesettings.DialogComponentBoolean;
 import org.knime.core.node.defaultnodesettings.DialogComponentStringSelection;
 import org.knime.knip.base.data.img.ImgPlusValue;
 import org.knime.knip.base.node.ValueToCellNodeDialog;
+import org.knime.knip.tess4j.base.node.ui.TessConfigTable;
 
 import net.imglib2.type.numeric.RealType;
 import net.sourceforge.tess4j.ITesseract;
@@ -101,6 +105,7 @@ public class Tess4JNodeDialog<T extends RealType<T>> extends ValueToCellNodeDial
 		super(true);
 
 		createOptionsTab();
+		createAdvancedConfigTab();
 		buildDialog();
 	}
 
@@ -162,6 +167,40 @@ public class Tess4JNodeDialog<T extends RealType<T>> extends ValueToCellNodeDial
 		m_dialogComponents.add(pageSegComp);
 		m_dialogComponents.add(ocrModeComp);
 		m_dialogComponents.add(deskewComp);
+	}
+
+	public void createAdvancedConfigTab() {
+		final JPanel contents = new JPanel(new BorderLayout());
+		final TessConfigTable tessConfigTable = new TessConfigTable(m_settings.tessAdvancedConfigModel());
+
+		final JButton btnAdd = new JButton("Add");
+		btnAdd.addActionListener((evt) -> tessConfigTable.model().addEmptyConfigEntry());
+
+		final JButton btnDel = new JButton("Remove");
+		btnDel.addActionListener(
+				(evt) -> tessConfigTable.model().removeConfigEntry(tessConfigTable.table().getSelectedRow()));
+
+		contents.add(tessConfigTable.getComponentPanel(), BorderLayout.CENTER);
+
+		final JPanel labelPanel = new JPanel(new GridBagLayout());
+		labelPanel.add(new JLabel("Tesseract configuration for advanced users."),
+				new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0, GridBagConstraints.FIRST_LINE_START,
+						GridBagConstraints.HORIZONTAL, new Insets(3, 3, 6, 3), 0, 0));
+		contents.add(labelPanel, BorderLayout.NORTH);
+
+		final JPanel buttons = new JPanel(new GridBagLayout());
+		buttons.add(btnAdd, new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0, GridBagConstraints.FIRST_LINE_START,
+				GridBagConstraints.HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0));
+		buttons.add(btnDel, new GridBagConstraints(0, 1, 1, 1, 0.0, 0.0, GridBagConstraints.FIRST_LINE_START,
+				GridBagConstraints.HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0));
+		buttons.add(new JPanel(), new GridBagConstraints(0, 2, 1, 1, 0.0, 1.0, GridBagConstraints.FIRST_LINE_START,
+				GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0)); /* filler */
+
+		contents.add(buttons, BorderLayout.EAST);
+
+		addTab("Advanced Config", contents);
+
+		m_dialogComponents.add(tessConfigTable);
 	}
 
 	@Override

--- a/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeDialog.java
+++ b/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeDialog.java
@@ -101,6 +101,8 @@ public class Tess4JNodeDialog<T extends RealType<T>> extends ValueToCellNodeDial
 
 	private final List<DialogComponent> m_dialogComponents = new ArrayList<DialogComponent>();
 
+	final TessConfigTable m_tessConfigTable = new TessConfigTable(m_settings.tessAdvancedConfigModel());
+
 	public Tess4JNodeDialog() {
 		super(true);
 
@@ -178,16 +180,16 @@ public class Tess4JNodeDialog<T extends RealType<T>> extends ValueToCellNodeDial
 	 */
 	private void createAdvancedConfigTab() {
 		final JPanel contents = new JPanel(new BorderLayout());
-		final TessConfigTable tessConfigTable = new TessConfigTable(m_settings.tessAdvancedConfigModel());
 
+		/* add button */
 		final JButton btnAdd = new JButton("Add");
-		btnAdd.addActionListener((evt) -> tessConfigTable.model().addEmptyConfigEntry());
+		btnAdd.addActionListener((evt) -> m_tessConfigTable.model().addEmptyConfigEntry());
 
 		final JButton btnDel = new JButton("Remove");
 		btnDel.addActionListener(
-				(evt) -> tessConfigTable.model().removeConfigEntry(tessConfigTable.table().getSelectedRow()));
+				(evt) -> m_tessConfigTable.model().removeConfigEntry(m_tessConfigTable.table().getSelectedRow()));
 
-		contents.add(tessConfigTable.getComponentPanel(), BorderLayout.CENTER);
+		contents.add(m_tessConfigTable.getComponentPanel(), BorderLayout.CENTER);
 
 		final JPanel labelPanel = new JPanel(new GridBagLayout());
 		labelPanel.add(new JLabel("Tesseract configuration for advanced users."),
@@ -207,7 +209,7 @@ public class Tess4JNodeDialog<T extends RealType<T>> extends ValueToCellNodeDial
 
 		addTab("Advanced Config", contents);
 
-		m_dialogComponents.add(tessConfigTable);
+		m_dialogComponents.add(m_tessConfigTable);
 	}
 
 	@Override

--- a/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeDialog.java
+++ b/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeDialog.java
@@ -103,6 +103,9 @@ public class Tess4JNodeDialog<T extends RealType<T>> extends ValueToCellNodeDial
 
 	final TessConfigTable m_tessConfigTable = new TessConfigTable(m_settings.tessAdvancedConfigModel());
 
+	/**
+	 * Constructor
+	 */
 	public Tess4JNodeDialog() {
 		super(true);
 
@@ -185,6 +188,7 @@ public class Tess4JNodeDialog<T extends RealType<T>> extends ValueToCellNodeDial
 		final JButton btnAdd = new JButton("Add");
 		btnAdd.addActionListener((evt) -> m_tessConfigTable.model().addEmptyConfigEntry());
 
+		/* remove button */
 		final JButton btnDel = new JButton("Remove");
 		btnDel.addActionListener(
 				(evt) -> m_tessConfigTable.model().removeConfigEntry(m_tessConfigTable.table().getSelectedRow()));

--- a/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeFactory.xml
+++ b/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeFactory.xml
@@ -124,6 +124,18 @@ http://knime.org/node/v2.10.xsd">
 				</ul>
 			</option>
 		</tab>
+		<tab name="Advanced Config">
+			<option name="Tesseract Config" optional="true">
+				<p> This allows defining key/value pairs as user-defined tesseract configuration variables. There are
+					<a href="http://www.sk-spell.sk.cx/tesseract-ocr-parameters-in-302-version">many of them</a>.</p>
+
+				<p> Advanced users can use this tab to make use of tesseracts flexibility, but <b>may result in unexpected
+					errors</b>, since the variables are not checked for correctness.</p>
+
+				<p> The "Import" and "Export" buttons allow you to load and write tesseract configuration files from the
+					list.</p>
+			</option>
+		</tab>
 	</fullDescription>
 
 	<ports>

--- a/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeModel.java
+++ b/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeModel.java
@@ -56,6 +56,7 @@ import org.knime.core.data.def.StringCell;
 import org.knime.core.node.ExecutionContext;
 import org.knime.core.node.defaultnodesettings.SettingsModel;
 import org.knime.core.node.port.PortObject;
+import org.knime.core.util.Pair;
 import org.knime.knip.base.data.img.ImgPlusValue;
 import org.knime.knip.base.node.ValueToCellNodeModel;
 import org.knime.knip.core.awt.Real2GreyRenderer;
@@ -119,6 +120,11 @@ public class Tess4JNodeModel<T extends RealType<T>> extends ValueToCellNodeModel
 		}
 
 		getLogger().debug("Initialized tesseract.");
+
+		/* load custom config key-value pairs */
+		for (final Pair<String, String> config : m_settings.tessAdvancedConfig()) {
+			m_tessInstance.setTessVariable(config.getFirst(), config.getSecond());
+		}
 
 		m_tessInstance.setTessVariables();
 	}

--- a/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeSettings.java
+++ b/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeSettings.java
@@ -210,19 +210,31 @@ public class Tess4JNodeSettings {
 	}
 
 	/**
+	 * Convert a list of string pairs to an arraylist of strings in the form of
+	 * <code>pair.getFirst() + " " + pair.getSecond()</code>.
+	 * 
+	 * @param pairs
+	 *            the list of string pairs
+	 * @return
+	 */
+	public static String[] toStringArray(final List<Pair<String, String>> pairs) {
+		final ArrayList<String> list = new ArrayList<>();
+
+		for (Pair<String, String> pair : pairs) {
+			list.add(pair.getFirst() + " " + pair.getSecond());
+		}
+
+		return list.toArray(new String[list.size()]);
+	}
+
+	/**
 	 * Set the key-value pairs for advanced configuration.
 	 * 
 	 * @param config
 	 *            the key-value pairs
 	 */
 	public void setTessAdvancedConfig(final List<Pair<String, String>> config) {
-		final ArrayList<String> list = new ArrayList<>();
-
-		for (Pair<String, String> pair : config) {
-			list.add(pair.getFirst() + " " + pair.getSecond());
-		}
-
-		m_advancedConfig.setStringArrayValue(list.toArray(new String[list.size()]));
+		m_advancedConfig.setStringArrayValue(toStringArray(config));
 	}
 
 	/**

--- a/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeSettings.java
+++ b/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeSettings.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.core.runtime.FileLocator;
@@ -207,6 +208,17 @@ public class Tess4JNodeSettings {
 		}
 
 		return list;
+	}
+
+	/**
+	 * Convenience method, see {@link #toTessConfigPairs(String[])}.
+	 * 
+	 * @param list
+	 *            to split up
+	 * @return the array list containing key-value pairs
+	 */
+	public static Collection<? extends Pair<String, String>> toTessConfigPairs(final List<String> list) {
+		return toTessConfigPairs(list.toArray(new String[list.size()]));
 	}
 
 	/**

--- a/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeSettings.java
+++ b/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/Tess4JNodeSettings.java
@@ -3,9 +3,8 @@ package org.knime.knip.tess4j.base.node;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
-
-import net.sourceforge.tess4j.ITesseract;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.knime.core.node.defaultnodesettings.SettingsModel;
@@ -13,6 +12,10 @@ import org.knime.core.node.defaultnodesettings.SettingsModelBoolean;
 import org.knime.core.node.defaultnodesettings.SettingsModelInteger;
 import org.knime.core.node.defaultnodesettings.SettingsModelOptionalString;
 import org.knime.core.node.defaultnodesettings.SettingsModelString;
+import org.knime.core.node.defaultnodesettings.SettingsModelStringArray;
+import org.knime.core.util.Pair;
+
+import net.sourceforge.tess4j.ITesseract;
 
 /**
  * Settings of the Tess4JNode.
@@ -26,6 +29,7 @@ public class Tess4JNodeSettings {
 	private final SettingsModelInteger m_pageSegMode = createTessPageSegModeModel();
 	private final SettingsModelInteger m_ocrEngineMode = createTessOcrEngineModeModel();
 	private final SettingsModelBoolean m_deskewModel = createTessDeskewModel();
+	private final SettingsModelStringArray m_advancedConfig = createTessAdvancedConfigModel();
 
 	/**
 	 * Creates a SetingsModel for the Tesseract Language
@@ -73,6 +77,16 @@ public class Tess4JNodeSettings {
 	}
 
 	/**
+	 * Creates a SettingsModel for the advanced tesseract config key-value pair
+	 * list
+	 * 
+	 * @return
+	 */
+	public static SettingsModelStringArray createTessAdvancedConfigModel() {
+		return new SettingsModelStringArray("TessConfig", new String[] {});
+	}
+
+	/**
 	 * Add settings to settingsModels.
 	 * 
 	 * @param settingsModels
@@ -83,6 +97,7 @@ public class Tess4JNodeSettings {
 		settingsModels.add(m_pageSegMode);
 		settingsModels.add(m_ocrEngineMode);
 		settingsModels.add(m_deskewModel);
+		settingsModels.add(m_advancedConfig);
 	}
 
 	/**
@@ -114,10 +129,18 @@ public class Tess4JNodeSettings {
 	}
 
 	/**
-	 * @return {@link SettingsModel} for the OCR Engine to use.
+	 * @return {@link SettingsModel} for whether to use deskew.
 	 */
 	public SettingsModelBoolean deskewModel() {
 		return m_deskewModel;
+	}
+
+	/**
+	 * @return {@link SettingsModel} for advanced tesseract config key-value
+	 *         pairs.
+	 */
+	public SettingsModelStringArray tessAdvancedConfigModel() {
+		return m_advancedConfig;
 	}
 
 	/**
@@ -158,6 +181,48 @@ public class Tess4JNodeSettings {
 	 */
 	public boolean useDeskew() {
 		return deskewModel().getBooleanValue();
+	}
+
+	/**
+	 * @return the tesseract configuration key-value pairs
+	 */
+	public List<Pair<String, String>> tessAdvancedConfig() {
+		return toTessConfigPairs(m_advancedConfig.getStringArrayValue());
+	}
+
+	/**
+	 * Turn an array of strings into a ArrayList of String pairs by splitting at
+	 * the first ' '.
+	 * 
+	 * @param strings
+	 *            array to split up
+	 * @return the array list containing key-value pairs
+	 */
+	public static ArrayList<Pair<String, String>> toTessConfigPairs(final String[] strings) {
+		final ArrayList<Pair<String, String>> list = new ArrayList<>();
+
+		for (String line : strings) {
+			final int index = line.indexOf(' ');
+			list.add(new Pair<String, String>(line.substring(0, index), line.substring(index + 1)));
+		}
+
+		return list;
+	}
+
+	/**
+	 * Set the key-value pairs for advanced configuration.
+	 * 
+	 * @param config
+	 *            the key-value pairs
+	 */
+	public void setTessAdvancedConfig(final List<Pair<String, String>> config) {
+		final ArrayList<String> list = new ArrayList<>();
+
+		for (Pair<String, String> pair : config) {
+			list.add(pair.getFirst() + " " + pair.getSecond());
+		}
+
+		m_advancedConfig.setStringArrayValue(list.toArray(new String[list.size()]));
 	}
 
 	/**

--- a/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/ui/TessConfigTable.java
+++ b/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/ui/TessConfigTable.java
@@ -1,0 +1,91 @@
+package org.knime.knip.tess4j.base.node.ui;
+
+import java.awt.BorderLayout;
+
+import javax.swing.DefaultCellEditor;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.table.TableColumn;
+
+import org.knime.core.node.InvalidSettingsException;
+import org.knime.core.node.NotConfigurableException;
+import org.knime.core.node.defaultnodesettings.DialogComponent;
+import org.knime.core.node.defaultnodesettings.SettingsModelStringArray;
+import org.knime.core.node.port.PortObjectSpec;
+import org.knime.knip.tess4j.base.node.Tess4JNodeSettings;
+
+/**
+ * Table containing key-value config pairs for tesseract.
+ * 
+ * @author Jonathan Hale
+ *
+ */
+public class TessConfigTable extends DialogComponent {
+
+	final TessConfigTableModel m_model = new TessConfigTableModel();
+	final JTable m_table = new JTable(m_model);
+	final SettingsModelStringArray m_settingsModel;
+
+	public TessConfigTable(final SettingsModelStringArray model) {
+		super(model);
+		m_settingsModel = model;
+
+		/* add table to DialogComponent content pane */
+		final JScrollPane tableScrollPane = new JScrollPane(m_table);
+		m_table.setFillsViewportHeight(true);
+
+		final JPanel panel = this.getComponentPanel();
+		panel.setLayout(new BorderLayout());
+		panel.add(tableScrollPane, BorderLayout.CENTER);
+		panel.add(m_table.getTableHeader(), BorderLayout.PAGE_START);
+
+		/* setup column cell editors */
+		final DefaultCellEditor editor = new DefaultCellEditor(new JTextField());
+		editor.setClickCountToStart(1);
+
+		final TableColumn keyColumn = m_table.getColumnModel().getColumn(0);
+		keyColumn.setCellEditor(editor);
+
+		final TableColumn valColumn = m_table.getColumnModel().getColumn(1);
+		valColumn.setCellEditor(editor);
+	}
+
+	@Override
+	protected void updateComponent() {
+		m_model.contents().clear();
+		m_model.contents().addAll(Tess4JNodeSettings.toTessConfigPairs(m_settingsModel.getStringArrayValue()));
+	}
+
+	@Override
+	protected void validateSettingsBeforeSave() throws InvalidSettingsException {
+		m_settingsModel.setStringArrayValue(Tess4JNodeSettings.toStringArray(m_model.contents()));
+	}
+
+	@Override
+	protected void checkConfigurabilityBeforeLoad(PortObjectSpec[] specs) throws NotConfigurableException {
+		// nothing to do
+	}
+
+	@Override
+	protected void setEnabledComponents(boolean enabled) {
+		m_table.setEnabled(enabled);
+	}
+
+	@Override
+	public void setToolTipText(String text) {
+		m_table.setToolTipText(text);
+	}
+
+	/**
+	 * @return the underlying table model
+	 */
+	public TessConfigTableModel model() {
+		return m_model;
+	}
+
+	public JTable table() {
+		return m_table;
+	}
+}

--- a/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/ui/TessConfigTableModel.java
+++ b/org.knime.knip.tess4j.base/src/org/knime/knip/tess4j/base/node/ui/TessConfigTableModel.java
@@ -1,0 +1,103 @@
+package org.knime.knip.tess4j.base.node.ui;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.table.AbstractTableModel;
+
+import org.knime.core.util.Pair;
+import org.knime.knip.tess4j.base.node.Tess4JNodeSettings;
+
+/**
+ * Table model which stores tesseract key value config pairs.
+ * 
+ * @author Jonathan Hale
+ */
+public class TessConfigTableModel extends AbstractTableModel {
+
+	private static final long serialVersionUID = 42L;
+
+	private final ArrayList<Pair<String, String>> m_contents = new ArrayList<>();
+
+	@Override
+	public int getColumnCount() {
+		return 2;
+	}
+
+	@Override
+	public int getRowCount() {
+		return m_contents.size();
+	}
+
+	@Override
+	public String getColumnName(int column) {
+		return (column == 0) ? "Key" : "Value";
+	}
+
+	@Override
+	public Object getValueAt(int rowIndex, int columnIndex) {
+		final Pair<String, String> pair = m_contents.get(rowIndex);
+		return (columnIndex == 0) ? pair.getFirst() : pair.getSecond();
+	}
+
+	/**
+	 * @return List which contains the values stored in the table.
+	 */
+	public List<Pair<String, String>> contents() {
+		return m_contents;
+	}
+
+	/**
+	 * Create a new config entry with key <code>""</code> and value
+	 * <code>""</code>.
+	 */
+	public void addEmptyConfigEntry() {
+		final int index = m_contents.size();
+
+		m_contents.add(new Pair<>("", ""));
+
+		this.fireTableRowsInserted(index, index);
+	}
+
+	/**
+	 * Remove config entry at the given row index.
+	 * 
+	 * @param index
+	 *            the row index to remove a value at
+	 */
+	public void removeConfigEntry(int index) {
+		if (index < 0)
+			return;
+		m_contents.remove(index);
+		this.fireTableRowsDeleted(index, index);
+	}
+
+	@Override
+	public void setValueAt(final Object aValue, int rowIndex, int columnIndex) {
+		if (!(aValue instanceof String)) {
+			return;
+		}
+
+		final String stringValue = (String) aValue;
+
+		/*
+		 * Pair is immutable, so we need to create a new one if the value
+		 * changes
+		 */
+		if (columnIndex == 0) {
+			final Pair<String, String> existing = m_contents.get(rowIndex);
+			m_contents.set(rowIndex, new Pair<>(stringValue.replace(' ', '_'), existing.getSecond()));
+		} else if (columnIndex == 1) {
+			final Pair<String, String> existing = m_contents.get(rowIndex);
+			m_contents.set(rowIndex, new Pair<>(existing.getFirst(), stringValue));
+		} else {
+			throw new IndexOutOfBoundsException("Column index out of bounds.");
+		}
+	}
+
+	@Override
+	public boolean isCellEditable(int rowIndex, int columnIndex) {
+		return true;
+	}
+
+}


### PR DESCRIPTION
Hi @dietzc ,

finally done with the feature request from [the forum](https://tech.knime.org/forum/knime-image-processing/tess4j-follow-a-pattern).

I decided to blow this up a bit to allow setting all possible tesseract configuration variables via the dialog in a key-value pair table. Also export and import for existing tesseract configuration files is supported.

Regards, 
Jonathan